### PR TITLE
Fix all inputs containing non-ASCII characters got garbled

### DIFF
--- a/Network/CGI/Protocol.hs
+++ b/Network/CGI/Protocol.hs
@@ -33,11 +33,12 @@ module Network.CGI.Protocol (
  ) where
 
 import Control.Monad.Trans (MonadIO(..))
+import Data.Char (chr, isHexDigit, digitToInt)
 import Data.List (intersperse)
 import qualified Data.Map as Map
 import Data.Map (Map)
 import Data.Maybe (fromMaybe, listToMaybe, isJust)
-import Network.URI (unEscapeString,escapeURIString,isUnescapedInURI)
+import Network.URI (escapeURIString,isUnescapedInURI)
 import System.Environment (getEnvironment)
 import System.IO (Handle, hPutStrLn, stderr, hFlush, hSetBinaryMode)
 
@@ -227,6 +228,13 @@ formDecode s = (urlDecode n, urlDecode (drop 1 v)) : formDecode (drop 1 rs)
 --   application\/x-www-form-urlencoded encoding.
 urlDecode :: String -> String
 urlDecode = unEscapeString . replace '+' ' '
+
+-- | Unescape a percent-encoded string, but doesn't decode UTF-8 encoding.
+unEscapeString :: String -> String
+unEscapeString [] = ""
+unEscapeString ('%':x1:x2:s) | isHexDigit x1 && isHexDigit x2 =
+    chr (digitToInt x1 * 16 + digitToInt x2) : unEscapeString s
+unEscapeString (c:s) = c : unEscapeString s
 
 --
 -- * Request content and form-data stuff


### PR DESCRIPTION
As of network-2.4.1.0, Network.URI.unEscapeString converts an input to a Unicode string assuming the input is UTF-8 encoded bytes, as well as decodes the percent-encoding. As a result, this library converts all inputs to Unicode strings, then truncates all characters in the strings to 8bits with Data.ByteString.Lazy.Char8.pack.

I copied unEscapeString from the old network library that just unescapes the percent-encoding.
