### PR TITLE
Updates to support base-4.7 from GHC 7.7-2013116

### DIFF
--- a/Network/CGI/Protocol.hs
+++ b/Network/CGI/Protocol.hs
@@ -1,3 +1,8 @@
+{-# LANGUAGE CPP #-}
+#if MIN_VERSION_base(4,7,0)
+{-# LANGUAGE DeriveDataTypeable #-}
+#endif
+
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Network.CGI.Protocol
@@ -44,7 +49,11 @@ import System.IO (Handle, hPutStrLn, stderr, hFlush, hSetBinaryMode)
 import qualified Data.ByteString.Lazy.Char8 as BS
 import Data.ByteString.Lazy.Char8 (ByteString)
 
+#if MIN_VERSION_base(4,7,0)
+import Data.Typeable (Typeable())
+#else
 import Data.Typeable (Typeable(..), mkTyConApp, mkTyCon)
+#endif
 
 import Network.CGI.Header
 import Network.CGI.Multipart
@@ -70,11 +79,14 @@ data CGIRequest =
                 -- "multipart\/form-data" format.
                 cgiRequestBody :: ByteString
                }
+#if MIN_VERSION_base(4,7,0)
+    deriving (Show, Typeable)
+#else
     deriving (Show)
 
 instance Typeable CGIResult where
     typeOf _ = mkTyConApp (mkTyCon "Network.CGI.Protocol.CGIResult") []
-
+#endif
 -- | The value of an input parameter, and some metadata.
 data Input = Input {
                     inputValue :: ByteString,

--- a/cgi.cabal
+++ b/cgi.cabal
@@ -38,7 +38,7 @@ Library
     network >= 2.0,
     parsec >= 2.0,
     mtl >= 1.0,
-    MonadCatchIO-mtl,
+    MonadCatchIO-transformers,
     xhtml >= 3000.0.0
   If flag(split-base)
     Build-depends: base >= 3 && < 5, old-time, old-locale, containers


### PR DESCRIPTION
Adds updates to support the new Typeable in base-4.7.0.0. 
Switches from MonadCatchIO-mtl to MonadCatchIO-transformers (latter is supported in 7.8)
Adds explicit (Functor m) constraint on tryCGI (this is the only source change not in #if MIN_VERSION_base(4,7,0) blocks). 
