### PR TITLE
Expose Network.CGI.Multipart.

### DIFF
--- a/cgi.cabal
+++ b/cgi.cabal
@@ -25,9 +25,9 @@ Library
     Network.CGI.Protocol,
     Network.CGI.Cookie,
     Network.CGI.Compat
+    Network.CGI.Multipart
   Other-modules:
     Network.CGI.Accept,
-    Network.CGI.Multipart,
     Network.CGI.Header
   Extensions:
     CPP,


### PR DESCRIPTION
I needed a multipart/mixed parser and pretty printer, and the cgi package seemed to have the best/only complete one. However, it was not exposed. This commit exposes the module.
