### PR TITLE
Fix Functor constraint for use of try.

### DIFF
--- a/Network/CGI/Monad.hs
+++ b/Network/CGI/Monad.hs
@@ -119,7 +119,7 @@ catchCGI = catch
 
 -- | Catches any exception thrown by an CGI action, and returns either
 --   the exception, or if no exception was raised, the result of the action.
-tryCGI :: (MonadCGI m, MonadCatchIO m) => m a -> m (Either SomeException a)
+tryCGI :: (Functor m, MonadCGI m, MonadCatchIO m) => m a -> m (Either SomeException a)
 tryCGI = try
 
 {-# DEPRECATED handleExceptionCGI "Use catchCGI instead." #-}


### PR DESCRIPTION
Add an innocent constraint on `Functor` to support all versions of `MonadCatchIO-mtl`, including the latest (0.3.1.0) which added this constraint.
