### PR TITLE
Make cgi 7.8 ready

### DIFF
--- a/cgi.cabal
+++ b/cgi.cabal
@@ -1,5 +1,5 @@
 Name: cgi
-Version: 3001.1.8.5
+Version: 3001.2.8.5
 Copyright: Bjorn Bringert, Andy Gill, Anders Kaseorg, Ian Lynagh, 
            Erik Meijer, Sven Panne, Jeremy Shaw
 Category: Network


### PR DESCRIPTION
Builds under the latest platform and 7.8-RC2.

A different approach than the one taken in the other PR.

There may be a more elegant solution, I just followed the
common pattern I've seen in a few other libraries.

The version bump may also be overly aggressive.
